### PR TITLE
Issue #14: Generate eGUIDs from GUIDs - use raw bytes - code cleanup

### DIFF
--- a/guids-generator.html
+++ b/guids-generator.html
@@ -249,7 +249,7 @@ require(["bcrypt", "jsencrypt"], function(bcrypt, jsencrypt) {
       dateFormatted[specs.dayIndex]  = (date.d < 10 ? "0" : 0) + date.d;
       dateFormatted[specs.montIndex] = (date.m < 10 ? "0" : 0) + date.m;
       dateFormatted[specs.yearIndex] = date.y;
-      return dateFormatted.join(specs.separator);
+      return dateFormatted.join("");
     }
 
     let validatedateDate = (dateText, format) => {
@@ -456,7 +456,7 @@ require(["bcrypt", "jsencrypt"], function(bcrypt, jsencrypt) {
                 }
 
                 // If the input is found valid, concatenate the post-processed health card number and date of birth and generate the GUID
-                postProcessed.push({"index": index, "info" : info, "value": info[HC] + info[PROVINCE]});
+                postProcessed.push({"index": index, "info" : info, "value": info[HC] + info[PROVINCE] + info[DOB]});
             }
 
             setValidatedData(postProcessed);

--- a/guids-generator.html
+++ b/guids-generator.html
@@ -466,10 +466,78 @@ require(["bcrypt", "jsencrypt"], function(bcrypt, jsencrypt) {
             /*
              For now, we use the bcrypt.hash() function.
              However all hashing of personal health information (PHI)
-             will be done using this function so that, if necessary,
-             switching to a new hashing function/algorithm will be
-             greatly simplified.
+             will be done using this (phiHashFunction) function so that,
+             if necessary, switching to a new hashing function/algorithm
+             will be greatly simplified.
             */
+
+            /*
+             Port of static void decode_base64(u_int8_t *buffer, u_int16_t len, u_int8_t *data)
+             from https://github.com/kelektiv/node.bcrypt.js -- src/bcrypt.cc
+            */
+            const decode_bcrypt_base64 = (b64data, len) => {
+                const index_64 = [
+                    255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+                    255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+                    255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+                    255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+                    255, 255, 255, 255, 255, 255, 0, 1, 54, 55,
+                    56, 57, 58, 59, 60, 61, 62, 63, 255, 255,
+                    255, 255, 255, 255, 255, 2, 3, 4, 5, 6,
+                    7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+                    17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27,
+                    255, 255, 255, 255, 255, 255, 28, 29, 30,
+                    31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+                    41, 42, 43, 44, 45, 46, 47, 48, 49, 50,
+                    51, 52, 53, 255, 255, 255, 255, 255
+                ];
+
+                const CHAR64 = (c) => {
+                    return ( (c > 127) ? 255 : index_64[c.charCodeAt(0)] );
+                };
+
+                let output = [];
+                for (let i = 0; i < len; i++) {
+                    output.push(0);
+                }
+
+                let bp = 0;
+                let p = 0;
+                while (bp < len) {
+                    let c1 = CHAR64(b64data[p]);
+                    let c2 = CHAR64(b64data[p + 1]);
+
+                    /* Invalid data */
+                    if (c1 == 255 || c2 == 255) {
+                        break;
+                    }
+
+                    output[bp++] = (c1 << 2) | ((c2 & 0x30) >> 4);
+                    if (bp >= len) {
+                        break;
+                    }
+
+                    let c3 = CHAR64(b64data[p + 2]);
+                    if (c3 == 255) {
+                        break;
+                    }
+
+                    output[bp++] = ((c2 & 0x0f) << 4) | ((c3 & 0x3c) >> 2);
+                    if (bp >= len) {
+                        break;
+                    }
+
+                    let c4 = CHAR64(b64data[p + 3]);
+                    if (c4 == 255) {
+                        break;
+                    }
+                    output[bp++] = ((c3 & 0x03) << 6) | c4;
+
+                    p += 4;
+                }
+                return Uint8Array.from(output);
+            };
+
             bcrypt.hash(data, salt, (err, hash) => {
                 if (err) {
                     callback(err, undefined);
@@ -478,9 +546,12 @@ require(["bcrypt", "jsencrypt"], function(bcrypt, jsencrypt) {
                      Turn the base64 encoded hash (remove salt version, rounds number and actual salt)
                      into a Typed Array that we can work with byte-by-byte. The number -31 is specified
                      as the actual hash value calculated by the bcrypt module is in the last 31
-                     characters of its output. See https://www.npmjs.com/package/bcrypt, "Hash Info" section
+                     characters of its output. See https://www.npmjs.com/package/bcrypt, "Hash Info"
+                     section. The number 23 is obtained from  4 * BCRYPT_BLOCKS - 1 in the
+                     void bcrypt(const char *key, size_t key_len, const char *salt, char *encrypted)
+                     method from https://github.com/kelektiv/node.bcrypt.js -- src/bcrypt.cc
                     */
-                    let hashBytes = Uint8Array.from(window.atob(hash.slice(-31)), (c) => c.charCodeAt(0));
+                    let hashBytes = decode_bcrypt_base64(hash.slice(-31), 23);
                     callback(undefined, hashBytes);
                 }
             });

--- a/guids-generator.html
+++ b/guids-generator.html
@@ -576,7 +576,7 @@ require(["bcrypt", "jsencrypt"], function(bcrypt, jsencrypt) {
 
                         if (!enableObfuscation) {
                             // Encode the hash in HEX to ensure only alphanumeric characters are generated
-                            encrypted = hash.map(x => x.toString(16).padStart(2, "0")).join("");
+                            encrypted = [ ...hash ].map(x => x.toString(16).padStart(2, "0")).join("");
                         } else {
                             // Interlace the hash with random noise bytes
                             let noisyhash = new Uint8Array(2 * hash.length);

--- a/guids-generator.html
+++ b/guids-generator.html
@@ -462,6 +462,30 @@ require(["bcrypt", "jsencrypt"], function(bcrypt, jsencrypt) {
             setValidatedData(postProcessed);
         }
 
+        let phiHashFunction = (data, salt, callback) => {
+            /*
+             For now, we use the bcrypt.hash() function.
+             However all hashing of personal health information (PHI)
+             will be done using this function so that, if necessary,
+             switching to a new hashing function/algorithm will be
+             greatly simplified.
+            */
+            bcrypt.hash(data, salt, (err, hash) => {
+                if (err) {
+                    callback(err, undefined);
+                } else {
+                    /*
+                     Turn the base64 encoded hash (remove salt version, rounds number and actual salt)
+                     into a Typed Array that we can work with byte-by-byte. The number -31 is specified
+                     as the actual hash value calculated by the bcrypt module is in the last 31
+                     characters of its output. See https://www.npmjs.com/package/bcrypt, "Hash Info" section
+                    */
+                    let hashBytes = Uint8Array.from(window.atob(hash.slice(-31)), (c) => c.charCodeAt(0));
+                    callback(undefined, hashBytes);
+                }
+            });
+        }
+
         let onSubmit = () => {
 
             let hashes = {};
@@ -471,7 +495,7 @@ require(["bcrypt", "jsencrypt"], function(bcrypt, jsencrypt) {
                     hashes[item.index] = item;
                     (Object.keys(hashes).length == validatedData.length) && setBhashes(hashes);
                 } else {
-                    bcrypt.hash(item.value + projectId, salt, (err, hash) => {
+                    phiHashFunction(item.value + projectId, salt, (err, hash) => {
                         if (err) {
                             console.error(err);
                             return;
@@ -480,19 +504,9 @@ require(["bcrypt", "jsencrypt"], function(bcrypt, jsencrypt) {
                         let encrypted = '';
 
                         if (!enableObfuscation) {
-                            // Remove salt version, rounds number and actual salt from hash
                             // Encode the hash in HEX to ensure only alphanumeric characters are generated
-                            encrypted = hash.replace(salt, '')
-                                 .split("")
-                                 .map(c => c.charCodeAt(0).toString(16).padStart(2, "0"))
-                                 .join("");
+                            encrypted = hash.map(x => x.toString(16).padStart(2, "0")).join("");
                         } else {
-                            /*
-                             Turn the base64 encoded hash (remove salt version, rounds number and actual salt)
-                             into a Typed Array that we can work with byte-by-byte.
-                            */
-                            hash = Uint8Array.from(window.atob(hash.slice(-31)), (c) => c.charCodeAt(0));
-
                             // Interlace the hash with random noise bytes
                             let noisyhash = new Uint8Array(2 * hash.length);
                             for (let i = 0; i < hash.length; i++) {


### PR DESCRIPTION
This PR fixes several issues associated with the previously merged PR https://github.com/data-team-uhn/guid-generator-web/pull/17 namely:

- The Personal Health Information (PHI) hashing function (currently we are using _bcrypt_) has been wrapped by the `phiHashFunction` function so that the hashing algorithm can easily be switched to a different one if needed and the `phiHashFunction` can be shared between both client and server Javascript programs. This `phiHashFunction` function removes all non-hash information (eg. salt, version number, etc...) and returns the hash as a `Uint8Array` of bytes.
- The base64 decoding of the hash output from _bcrypt_ has been fixed. `window.atob()` does not work as _bcrypt_ uses non-standardized base64 encoding and `window.atob()` cannot handle the `.` and `/` characters.

To test:
- Setting `enableObfuscation` in `project-config.json` to `false` will cause the application to generate GUIDs. 
- Generated GUIDs should be deterministic - the same `<Health card,Province code,Date of birth>` should _always_ generate the same GUID.
- Changing even just one of the _Health card_, _Province code_, or _Date of birth_ values should result in a different GUID.


- Setting `enableObfuscation` in `project-config.json` to `true` will cause the application to generate eGUIDs.
- Generated eGUIDs should be non-deterministic - the same `<Health card,Province code,Date of birth>` should generate different eGUIDs.
- Test with the `issues-13-14_code-cleanup_test` branch and open the browser's web console. The value associated with the`Working with: ...` message should deterministic with respect to the _Health card_, _Province code_, and _Date of birth_ values, while the output displayed in the _eGUID_ table column should be non-deterministic. The value associated with the `Round-trip, base64 re-encoded to: ...` message should _always_ be the same as the value associated with the previous `Working with: ...` message.